### PR TITLE
Fix: pass separate_comments in REST classic-theme render

### DIFF
--- a/includes/services/class-comments-renderer.php
+++ b/includes/services/class-comments-renderer.php
@@ -132,8 +132,9 @@ class CommentsRenderer {
 			echo do_blocks( $block );
 		} else {
 			// Classic themes fall through to the standard
-			// `comments_template()` lookup.
-			comments_template( '' );
+			// `comments_template()` lookup. Pass true so themes such as
+			// Genesis receive separated comment types in $wp_query.
+			comments_template( '', true );
 		}
 
 		$html = ob_get_clean();


### PR DESCRIPTION
Genesis and similar themes need comments_template( '', true ) so wp_query comments_by_type is populated. Without it, genesis_do_comments() skips the list while the reply form still renders.